### PR TITLE
Change package name for linking purposes

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="fr.ayoubdev.rnac"
+      package="fr.ayoubdev.rnak"
       android:versionCode="1"
       android:versionName="1.1">
 </manifest>


### PR DESCRIPTION
When using `rnpm link` the import statement is incorrectly pointing to `rnac` instead of `rnak`